### PR TITLE
ci: skip on draft PRs

### DIFF
--- a/.github/workflows/ci-dagger.yaml
+++ b/.github/workflows/ci-dagger.yaml
@@ -9,6 +9,7 @@ jobs:
   lint:
     name: Golangci-lint
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - name: Checkout repository
@@ -24,6 +25,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - name: Checkout repository
@@ -39,6 +41,7 @@ jobs:
   e2e-test:
     name: E2E Test
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - name: Checkout repository
@@ -54,6 +57,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Make sure to pass `kustomize build` the following flags:
 Cuestomize is able to integrate with any CUE model respecting the following constraints:
 - The model accepts a `input` section (you are free to decide the structure of this section to match the expected KRM input structure)
 - The model has an `outputs` section which is a slice of KRM resources. This field will hold the generated resources
-- The model (optionally) accepts an `includes` section which is a map `<group>:<version>:<kind>:<namespace>:<name>:{resource}` of resources that are forwarded from the kustomize input stream to the CUE model.
+- The model (optionally) accepts an `includes` section which is a map `<apiVersion>:<kind>:<namespace>:<name>:{resource}` of resources that are forwarded from the kustomize input stream to the CUE model.

--- a/hack/generate-testdata.sh
+++ b/hack/generate-testdata.sh
@@ -2,8 +2,4 @@
 
 set -e
 
-#!/bin/bash
-
-set -e
-
 ./hack/generate-cue-modules.sh ./testdata/function/cue-modules ../../../../api


### PR DESCRIPTION
## Changes
- Skip running CI on draft Pull Requests
- Fix duplicate shebang in generate examples hack.