### PR TITLE
fix: Fix CUE module fetch failure in KRM function container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,8 @@ RUN CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -o 
 
 FROM gcr.io/distroless/static:latest
 
+ENV CUE_CACHE_DIR=/tmp/cue-cache
+
 COPY --from=builder /workspace/cuestomize /usr/local/bin/cuestomize
 
 ENTRYPOINT ["/usr/local/bin/cuestomize"]


### PR DESCRIPTION
The distroless base image (`gcr.io/distroless/static`) sets `HOME=/nonexistent`, which is not writable. When CUE attempts to fetch remote modules at runtime, it tries to create its cache directory under `$HOME`, resulting in:

```
mkdir /nonexistent: permission denied
```
This sets `CUE_CACHE_DIR=/tmp/cue-cache` to give CUE a writable location for its module cache.